### PR TITLE
feat: GroupCommit

### DIFF
--- a/map.go
+++ b/map.go
@@ -51,8 +51,8 @@ func (p *mapProcessor) Process(ctx context.Context, inputs <-chan Record, abort 
 
 	go func() {
 		for in := range inputs {
-			// EmptyGroupは無視する
-			if _, ok := in.(emptyGroup); ok {
+			// GroupCommitは無視する
+			if _, ok := in.(groupCommit); ok {
 				continue
 			}
 

--- a/map_test.go
+++ b/map_test.go
@@ -28,7 +28,7 @@ func Test_mapProcessor_Process(t *testing.T) {
 				inputs: []Record{
 					testRecord{"group1", "id1"},
 					testRecord{"error", "id2"},
-					emptyGroup{GroupString("group2")},
+					GroupCommit(GroupString("group2")),
 				},
 			},
 			want: []Output{
@@ -38,7 +38,7 @@ func Test_mapProcessor_Process(t *testing.T) {
 					Records: []Record{
 						testRecord{"group1_mapped", "id1_1"},
 						testRecord{"group1_mapped", "id1_2"},
-						emptyGroup{GroupString("group1_empty")},
+						GroupCommit(GroupString("group1_empty")),
 					},
 				},
 				{
@@ -74,7 +74,7 @@ func Test_mapProcessor_Process(t *testing.T) {
 					Records: []Record{
 						testRecord{"group1_mapped", "id1_1"},
 						testRecord{"group1_mapped", "id1_2"},
-						emptyGroup{GroupString("group1_empty")},
+						GroupCommit(GroupString("group1_empty")),
 					},
 				},
 				// 順番に処理されるので、timeout以降のものは全てtimeoutとして処理される

--- a/process.go
+++ b/process.go
@@ -48,7 +48,7 @@ func (o Output) Summarized() SummarizedOutput {
 	var recordCount int
 	for _, r := range o.Records {
 		groups[r.Group().String()] = struct{}{}
-		if _, ok := r.(emptyGroup); !ok {
+		if _, ok := r.(groupCommit); !ok {
 			recordCount++
 		}
 	}

--- a/process_test.go
+++ b/process_test.go
@@ -19,7 +19,7 @@ func TestOutput_Summarized(t *testing.T) {
 				Status: OutputStatusError,
 				Records: []Record{
 					testRecord{"group1", "id1"},
-					emptyGroup{GroupString("group2")},
+					GroupCommit(GroupString("group2")),
 				},
 				Err: errTestMapper,
 			},

--- a/record.go
+++ b/record.go
@@ -37,20 +37,25 @@ func (g GroupString) String() string {
 	return string(g)
 }
 
-// ReducerでRecordがないグループも扱いたい場合に使うRecord
-// Reducerのグループのリストを作成するために利用され、レコードとしては無視される
-type emptyGroup struct {
+// 特定のグループのレコードが全て出力されたことを示すレコード
+// Reducerのグループを確定させるために利用され、レコードとしては無視される
+type groupCommit struct {
 	group Group
 }
 
-func EmptyGroup(g Group) emptyGroup {
-	return emptyGroup{g}
+func GroupCommit(g Group) groupCommit {
+	return groupCommit{g}
 }
 
-func (g emptyGroup) Group() Group {
+func (g groupCommit) Group() Group {
 	return g.group
 }
 
-func (g emptyGroup) Identifier() string {
+func (g groupCommit) Identifier() string {
 	return na
+}
+
+// Deprecated: 代わりにGroupCommitを利用してください
+func EmptyGroup(g Group) groupCommit {
+	return groupCommit{g}
 }

--- a/reduce.go
+++ b/reduce.go
@@ -70,7 +70,13 @@ func (p *reduceProcessor) Process(ctx context.Context, inputs <-chan Record, abo
 		for in := range inputs {
 			gr := in.Group().String()
 
-			if _, ok := groups[gr]; !ok {
+			if g, ok := groups[gr]; ok {
+				// すでにコミットされたグループは無視する
+				if g.done {
+					continue
+				}
+			} else {
+				// 新しいグループの場合はグループ一覧に追加する
 				groups[gr] = &group{
 					group: in.Group(),
 					done:  false,

--- a/reduce.go
+++ b/reduce.go
@@ -59,51 +59,62 @@ func (p *reduceProcessor) Process(ctx context.Context, inputs <-chan Record, abo
 		eg.SetLimit(p.maxParallel)
 	}
 
+	type group struct {
+		group Group
+		done  bool
+	}
+
 	go func() {
-		groups := map[string]Group{}
+		groups := map[string]*group{}
 		groupedInputs := map[string][]Record{}
 		for in := range inputs {
 			gr := in.Group().String()
 
-			groups[gr] = in.Group()
-			if _, ok := in.(emptyGroup); !ok {
+			if _, ok := groups[gr]; !ok {
+				groups[gr] = &group{
+					group: in.Group(),
+					done:  false,
+				}
+			}
+
+			// GroupCommitが流れてきた場合、すぐにgroupの処理を開始して、レコードをmapから削除する
+			// こうすることで、必要以上にメモリを使用しないようにする
+			if _, ok := in.(groupCommit); ok {
+				groups[gr].done = true
+				inputs := groupedInputs[gr]
+				delete(groupedInputs, gr)
+
+				eg.Go(func() error {
+					output, err := p.reduce(ctx, in.Group(), inputs)
+					if err != nil {
+						return err
+					}
+					outputs <- output
+					return nil
+				})
+			} else {
 				groupedInputs[gr] = append(groupedInputs[gr], in)
 			}
 		}
 
+		// 全てのレコードを読んだら、GroupCommitされていないレコードを順に処理する
 		for _, group := range groups {
-			eg.Go(func() (err error) {
-				defer func() {
-					if err != nil {
-						outputs <- Output{
-							Unit:   group.String(),
-							Status: OutputStatusError,
-							Err:    err,
-						}
-						// abortIfAnyErrorがtrueの場合のみ、errを返して全体を止める
-						if !p.abortIfAnyError {
-							err = nil
-						}
-					}
-				}()
+			if group.done {
+				continue
+			}
 
-				select {
-				case <-ctx.Done():
-					return ctx.Err()
-				default:
-				}
+			gr := group.group.String()
 
-				o, err := p.reducer.Reduce(ctx, group, groupedInputs[group.String()])
+			groups[gr].done = true
+			inputs := groupedInputs[gr]
+			delete(groupedInputs, gr)
+
+			eg.Go(func() error {
+				output, err := p.reduce(ctx, group.group, inputs)
 				if err != nil {
 					return err
 				}
-
-				outputs <- Output{
-					Unit:    group.String(),
-					Status:  OutputStatusSuccess,
-					Records: o,
-				}
-
+				outputs <- output
 				return nil
 			})
 		}
@@ -115,4 +126,35 @@ func (p *reduceProcessor) Process(ctx context.Context, inputs <-chan Record, abo
 	}()
 
 	return outputs
+}
+
+func (p *reduceProcessor) reduce(ctx context.Context, group Group, inputs []Record) (output Output, err error) {
+	defer func() {
+		// abortIfAnyErrorがfalseの場合は、errを返す代わりにエラーステータスを持った通常レコードを返す
+		if err != nil && !p.abortIfAnyError {
+			output = Output{
+				Unit:   group.String(),
+				Status: OutputStatusError,
+				Err:    err,
+			}
+			err = nil
+		}
+	}()
+
+	select {
+	case <-ctx.Done():
+		return Output{}, ctx.Err()
+	default:
+	}
+
+	o, err := p.reducer.Reduce(ctx, group, inputs)
+	if err != nil {
+		return Output{}, err
+	}
+
+	return Output{
+		Unit:    group.String(),
+		Status:  OutputStatusSuccess,
+		Records: o,
+	}, nil
 }

--- a/reduce_test.go
+++ b/reduce_test.go
@@ -32,7 +32,8 @@ func Test_reducerProcessor_Process(t *testing.T) {
 					testRecord{"group2", "id3"}, // ASSERT: GroupCommitされていないグループも正しく処理される
 					testRecord{"error", "id4"},
 					GroupCommit(GroupString("group3")),
-					testRecord{"group1", "id5"}, // ASSERT: GroupCommit後に流れてきたレコードは無視される
+					GroupCommit(GroupString("group3")), // ASSERT: 複数回同じGroupCommitが来ても無視される
+					testRecord{"group1", "id5"},        // ASSERT: GroupCommit後に流れてきたレコードは無視される
 				},
 			},
 			want: []Output{

--- a/reduce_test.go
+++ b/reduce_test.go
@@ -28,9 +28,11 @@ func Test_reducerProcessor_Process(t *testing.T) {
 				inputs: []Record{
 					testRecord{"group1", "id1"},
 					testRecord{"group1", "id2"},
-					testRecord{"group2", "id3"},
+					GroupCommit(GroupString("group1")),
+					testRecord{"group2", "id3"}, // ASSERT: GroupCommitされていないグループも正しく処理される
 					testRecord{"error", "id4"},
-					emptyGroup{GroupString("group3")},
+					GroupCommit(GroupString("group3")),
+					testRecord{"group1", "id5"}, // ASSERT: GroupCommit後に流れてきたレコードは無視される
 				},
 			},
 			want: []Output{

--- a/test_helper.go
+++ b/test_helper.go
@@ -34,7 +34,7 @@ func (m *testMapper) Map(ctx context.Context, input Record) ([]Record, error) {
 		return []Record{
 			testRecord{gr + "_mapped", input.Identifier() + "_1"},
 			testRecord{gr + "_mapped", input.Identifier() + "_2"},
-			emptyGroup{GroupString(gr + "_empty")},
+			GroupCommit(GroupString(gr + "_empty")),
 		}, nil
 	}
 	// Error


### PR DESCRIPTION
## Why
現在のReducerでは全レコードを待ってからしか処理を開始できない実装になっており、特定のグループのレコードが出力され終わっていても順次処理を開始するということができず、パフォーマンスやメモリ使用量の問題が発生していました。

## What
特定のグループのレコードの完了を示すGroupCommitという特殊なレコードを定義し、これが上流が流れてきた際にそのグループのレコードが完了したとみなしてReduceの処理を開始する機能を実装しました。
また、既存の実装であったEmptyGroupにより実現したい処理がGroupCommitでも実現可能なため、GroupCommitを使って置き換えを行いました。