### PR TITLE
feat: add abort error

### DIFF
--- a/error.go
+++ b/error.go
@@ -1,0 +1,25 @@
+package pipeline
+
+import "errors"
+
+type abortError struct {
+	err error
+}
+
+func (e *abortError) Error() string {
+	return e.err.Error()
+}
+
+func (e *abortError) Unwrap() error {
+	return e.err
+}
+
+// 全体のパイプラインを中止すべきクリティカルなエラーが発生した場合は、このエラーを返してください
+func AbortError(err error) error {
+	return &abortError{err}
+}
+
+func IsAbortError(err error) bool {
+	var e *abortError
+	return errors.As(err, &e)
+}

--- a/map.go
+++ b/map.go
@@ -65,7 +65,7 @@ func (p *mapProcessor) Process(ctx context.Context, inputs <-chan Record, abort 
 							Err:    err,
 						}
 						// abortIfAnyErrorがtrueの場合のみ、errを返して全体を止める
-						if !p.abortIfAnyError {
+						if !p.abortIfAnyError && !IsAbortError(err) {
 							err = nil
 						}
 					}

--- a/map_test.go
+++ b/map_test.go
@@ -91,7 +91,19 @@ func Test_mapProcessor_Process(t *testing.T) {
 			},
 		},
 		{
-			name: "abort",
+			name:   "abort",
+			mapper: newMapProcessor("test", &testMapperAbort{}),
+			args: args{
+				ctx: context.Background(),
+				inputs: []Record{
+					testRecord{"group1", "id1"},
+					testRecord{"error", "id3"},
+				},
+			},
+			wantErr: errTestMapper,
+		},
+		{
+			name: "abortIfAnyError (deprecated)",
 			mapper: func() *mapProcessor {
 				pr := newMapProcessor("test", &testMapper{})
 				pr.SetAbortIfAnyError(true)
@@ -126,7 +138,7 @@ func Test_mapProcessor_Process(t *testing.T) {
 
 			close(abort)
 			if tt.wantErr != nil {
-				assert.ErrorIs(t, tt.wantErr, <-abort)
+				assert.ErrorIs(t, <-abort, tt.wantErr)
 				return
 			}
 

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -304,6 +304,18 @@ func TestPipeline_Execute(t *testing.T) {
 			name: "abort",
 			fields: fields{
 				stages: []*PipelineStage{
+					MapStage("Generator", &testBrokenGenerator{}),
+				},
+			},
+			args: args{
+				ctx: context.Background(),
+			},
+			wantErr: errTestBrokenGenerator,
+		},
+		{
+			name: "abortIfAnyError (deprecated)",
+			fields: fields{
+				stages: []*PipelineStage{
 					MapStage("Generator", &testBrokenGenerator{}, StageAbortIfAnyError(true)),
 				},
 			},
@@ -320,7 +332,7 @@ func TestPipeline_Execute(t *testing.T) {
 			}
 			outputs, stages, err := p.Execute(tt.args.ctx)
 			if tt.wantErr != nil {
-				assert.ErrorIs(t, tt.wantErr, err)
+				assert.ErrorIs(t, err, tt.wantErr)
 				return
 			}
 

--- a/reduce.go
+++ b/reduce.go
@@ -137,7 +137,7 @@ func (p *reduceProcessor) Process(ctx context.Context, inputs <-chan Record, abo
 func (p *reduceProcessor) reduce(ctx context.Context, group Group, inputs []Record) (output Output, err error) {
 	defer func() {
 		// abortIfAnyErrorがfalseの場合は、errを返す代わりにエラーステータスを持った通常レコードを返す
-		if err != nil && !p.abortIfAnyError {
+		if err != nil && !p.abortIfAnyError && !IsAbortError(err) {
 			output = Output{
 				Unit:   group.String(),
 				Status: OutputStatusError,

--- a/reduce_test.go
+++ b/reduce_test.go
@@ -97,9 +97,22 @@ func Test_reducerProcessor_Process(t *testing.T) {
 			},
 		},
 		{
-			name: "abort",
+			name:    "abort",
+			reducer: newReduceProcessor("test", &testReducerAbort{}),
+			args: args{
+				ctx: context.Background(),
+				inputs: []Record{
+					testRecord{"group1", "id1"},
+					testRecord{"group2", "id2"},
+					testRecord{"error", "id3"},
+				},
+			},
+			wantErr: errTestReducer,
+		},
+		{
+			name: "abortIfAnyError (deprecated)",
 			reducer: func() *reduceProcessor {
-				pr := newReduceProcessor("test", &testReducer{})
+				pr := newReduceProcessor("test", &testReducerAbort{})
 				pr.SetAbortIfAnyError(true)
 				return pr
 			}(),
@@ -133,7 +146,7 @@ func Test_reducerProcessor_Process(t *testing.T) {
 
 			close(abort)
 			if tt.wantErr != nil {
-				assert.ErrorIs(t, tt.wantErr, <-abort)
+				assert.ErrorIs(t, <-abort, tt.wantErr)
 				return
 			}
 

--- a/stage.go
+++ b/stage.go
@@ -38,6 +38,7 @@ func StageMaxParallel(max int) PipelineStageOption {
 	}
 }
 
+// Deprecated: 代わりにAbortErrorを利用してください
 func StageAbortIfAnyError(value bool) PipelineStageOption {
 	return func(s *PipelineStage) {
 		s.processor.SetAbortIfAnyError(value)

--- a/test_helper.go
+++ b/test_helper.go
@@ -53,6 +53,16 @@ func (m *testMapper) Map(ctx context.Context, input Record) ([]Record, error) {
 	return nil, nil
 }
 
+type testMapperAbort struct{}
+
+func (m *testMapperAbort) Map(ctx context.Context, input Record) ([]Record, error) {
+	outputs, err := (&testMapper{}).Map(ctx, input)
+	if err != nil {
+		return nil, AbortError(err)
+	}
+	return outputs, nil
+}
+
 type testReducer struct{}
 
 var errTestReducer = fmt.Errorf("test reducer error")
@@ -88,6 +98,16 @@ func (g *testGenerator) Map(ctx context.Context, input Record) ([]Record, error)
 	}, nil
 }
 
+type testReducerAbort struct{}
+
+func (m *testReducerAbort) Reduce(ctx context.Context, group Group, inputs []Record) ([]Record, error) {
+	outputs, err := (&testReducer{}).Reduce(ctx, group, inputs)
+	if err != nil {
+		return nil, AbortError(err)
+	}
+	return outputs, nil
+}
+
 type testGeneratorTimeout struct{}
 
 // 適当に2つのレコードを生成する
@@ -105,5 +125,5 @@ type testBrokenGenerator struct{}
 var errTestBrokenGenerator = errors.New("test broken generator error")
 
 func (g *testBrokenGenerator) Map(ctx context.Context, input Record) ([]Record, error) {
-	return nil, errTestBrokenGenerator
+	return nil, AbortError(errTestBrokenGenerator)
 }


### PR DESCRIPTION
## What
StageAbortIfAnyErrorでは、ステージごとにしかクリティカルエラーによる処理の中断を制御できなかった。
今回AbortErrorというエラーを用意し、これを投げた場合に全体の処理を中止する設計とすることで、同じステージ内でもクリティカルなエラーとそうでないエラーを切り分けられるようにする。