### PR TITLE
refactor: use generics interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,12 +125,12 @@ Mapper / Reducer はそれぞれ次のようなインターフェースとして
 input には前段で出力されたレコードが入ります。型アサーションにより型を特定した上で必要な情報を参照します。
 
 ```go
-type Mapper interface {
-	Map(ctx context.Context, input Record) ([]Record, error)
+type Mapper[I Record, O Record] interface {
+	Map(ctx context.Context, input I) ([]O, error)
 }
 
-type Reducer interface {
-	Reduce(ctx context.Context, group Group, inputs []Record) ([]Record, error)
+type Reducer[I Record, O Record, G Group] interface {
+	Reduce(ctx context.Context, group G, inputs []I) ([]O, error)
 }
 ```
 
@@ -140,22 +140,20 @@ type Reducer interface {
 ```go
 type RegionLister struct{}
 
-func (l *RegionLister) Map(ctx context.Context, input pipeline.Record) ([]pipeline.Record, error) {
-	return []pipeline.Record{
-		&Region{Name: "ap-northeast-1"},
-		&Region{Name: "us-west-1"},
+func (l *RegionLister) Map(ctx context.Context, _ pipeline.Origin) ([]*Region, error) {
+	return []*Region{
+		{Name: "ap-northeast-1"},
+		{Name: "us-west-1"},
 	}, nil
 }
 
 type VMLister struct{}
 
-func (l *VMLister) Map(ctx context.Context, input pipeline.Record) ([]pipeline.Record, error) {
-	region := input.(*Region)
-
+func (l *VMLister) Map(ctx context.Context, region *Region) ([]*Instance, error) {
 	if region.Name == "ap-northeast-1" {
-		return []pipeline.Record{
-			&Instance{ID: "i-123"},
-			&Instance{ID: "i-456"},
+		return []*Instance{
+			{ID: "i-123"},
+			{ID: "i-456"},
 		}, nil
 	}
 
@@ -164,32 +162,28 @@ func (l *VMLister) Map(ctx context.Context, input pipeline.Record) ([]pipeline.R
 
 type Scanner struct{}
 
-func (l *Scanner) Map(ctx context.Context, input pipeline.Record) ([]pipeline.Record, error) {
-    instance := input.(*Instance)
+func (s *Scanner) Map(ctx context.Context, instance *Instance) ([]*Vulnerability, error) {
+	if instance.ID == "i-123" {
+		return nil, fmt.Errorf("failed to scan instance %s", instance.ID)
+	}
+	if instance.ID == "i-456" {
+		return []*Vulnerability{
+			{ID: "CVE-2020-5678"},
+			{ID: "CVE-2020-9012"},
+		}, nil
+	}
 
-    if instance.ID == "i-123" {
-    	return nil, fmt.Errorf("failed to scan instance %s", instance.ID)
-    }
-    if instance.ID == "i-456" {
-    	return []pipeline.Record{
-    		&Vulnerability{ID: "CVE-2020-5678"},
-    		&Vulnerability{ID: "CVE-2020-9012"},
-    	}, nil
-    }
-
-    return nil, nil
-
+	return nil, nil
 }
 
 type Counter struct{}
 
-func (c *Counter) Reduce(ctx context.Context, group pipeline.Group, inputs []pipeline.Record) ([]pipeline.Record, error) {
-    vulnerabilityID := group.String()
+func (c *Counter) Reduce(ctx context.Context, group pipeline.Group, vulnerabilities []*Vulnerability) ([]*VulnerabilityCount, error) {
+	vulnerabilityID := group.String()
 
-    return []pipeline.Record{
-    	&VulnerabilityCount{VulnerabilityID: vulnerabilityID, Count: len(inputs)},
-    }, nil
-
+	return []*VulnerabilityCount{
+		{VulnerabilityID: vulnerabilityID, Count: len(vulnerabilities)},
+	}, nil
 }
 ```
 

--- a/examples/main.go
+++ b/examples/main.go
@@ -27,10 +27,10 @@ func (r *Region) Identifier() string    { return r.Name }
 
 type RegionLister struct{}
 
-func (l *RegionLister) Map(ctx context.Context, input pipeline.Record) ([]pipeline.Record, error) {
-	return []pipeline.Record{
-		&Region{Name: "ap-northeast-1"},
-		&Region{Name: "us-west-1"},
+func (l *RegionLister) Map(ctx context.Context, _ pipeline.Origin) ([]*Region, error) {
+	return []*Region{
+		{Name: "ap-northeast-1"},
+		{Name: "us-west-1"},
 	}, nil
 }
 
@@ -45,13 +45,11 @@ func (i *Instance) Identifier() string    { return i.ID }
 
 type VMLister struct{}
 
-func (l *VMLister) Map(ctx context.Context, input pipeline.Record) ([]pipeline.Record, error) {
-	region := input.(*Region)
-
+func (l *VMLister) Map(ctx context.Context, region *Region) ([]*Instance, error) {
 	if region.Name == "ap-northeast-1" {
-		return []pipeline.Record{
-			&Instance{ID: "i-123"},
-			&Instance{ID: "i-456"},
+		return []*Instance{
+			{ID: "i-123"},
+			{ID: "i-456"},
 		}, nil
 	}
 
@@ -69,16 +67,14 @@ func (v *Vulnerability) Identifier() string    { return v.Instance.ID }
 
 type Scanner struct{}
 
-func (l *Scanner) Map(ctx context.Context, input pipeline.Record) ([]pipeline.Record, error) {
-	instance := input.(*Instance)
-
+func (s *Scanner) Map(ctx context.Context, instance *Instance) ([]*Vulnerability, error) {
 	if instance.ID == "i-123" {
 		return nil, fmt.Errorf("failed to scan instance %s", instance.ID)
 	}
 	if instance.ID == "i-456" {
-		return []pipeline.Record{
-			&Vulnerability{ID: "CVE-2020-5678"},
-			&Vulnerability{ID: "CVE-2020-9012"},
+		return []*Vulnerability{
+			{ID: "CVE-2020-5678"},
+			{ID: "CVE-2020-9012"},
 		}, nil
 	}
 
@@ -96,11 +92,11 @@ type VulnerabilityCount struct {
 func (v *VulnerabilityCount) Group() pipeline.Group { return pipeline.GroupString(v.VulnerabilityID) }
 func (v *VulnerabilityCount) Identifier() string    { return pipeline.IdentifierNA }
 
-func (c *Counter) Reduce(ctx context.Context, group pipeline.Group, inputs []pipeline.Record) ([]pipeline.Record, error) {
+func (c *Counter) Reduce(ctx context.Context, group pipeline.Group, vulnerabilities []*Vulnerability) ([]*VulnerabilityCount, error) {
 	vulnerabilityID := group.String()
 
-	return []pipeline.Record{
-		&VulnerabilityCount{VulnerabilityID: vulnerabilityID, Count: len(inputs)},
+	return []*VulnerabilityCount{
+		{VulnerabilityID: vulnerabilityID, Count: len(vulnerabilities)},
 	}, nil
 }
 

--- a/map.go
+++ b/map.go
@@ -7,21 +7,50 @@ import (
 )
 
 // <group1, id1> -> Mapper() -> list(<group2, id2>)
-type Mapper interface {
+// 利用者が実装する型
+type Mapper[I Record, O Record] interface {
+	Map(ctx context.Context, input I) ([]O, error)
+}
+
+// 内部処理で利用される、具体型を持ったinterface
+type mapper interface {
 	Map(ctx context.Context, input Record) ([]Record, error)
+}
+
+// Mapperをラップしてmapperインターフェースを実装する型
+type mapWrapper[I Record, O Record] struct {
+	mapper Mapper[I, O]
+}
+
+func (m *mapWrapper[I, O]) Map(ctx context.Context, input Record) ([]Record, error) {
+	i := input.(I)
+
+	outs, err := m.mapper.Map(ctx, i)
+	if err != nil {
+		return nil, err
+	}
+
+	var outputs []Record
+	for _, o := range outs {
+		outputs = append(outputs, o)
+	}
+
+	return outputs, nil
 }
 
 type mapProcessor struct {
 	name            string
-	mapper          Mapper
+	mapper          mapper
 	maxParallel     int
 	abortIfAnyError bool
 }
 
-func newMapProcessor(name string, mapper Mapper) *mapProcessor {
+func newMapProcessor[I Record, O Record](name string, mapper Mapper[I, O]) *mapProcessor {
 	return &mapProcessor{
-		name:   name,
-		mapper: mapper,
+		name: name,
+		mapper: &mapWrapper[I, O]{
+			mapper: mapper,
+		},
 	}
 }
 

--- a/pipeline.go
+++ b/pipeline.go
@@ -18,7 +18,7 @@ func New(stages ...*PipelineStage) *Pipeline {
 func (p *Pipeline) Execute(ctx context.Context) (outputs []Record, stages []StageExecution, abortErr error) {
 	originInputs := make(chan Record)
 	go func() {
-		originInputs <- originInput{}
+		originInputs <- Origin{}
 		close(originInputs)
 	}()
 

--- a/record.go
+++ b/record.go
@@ -11,13 +11,13 @@ type Group interface {
 }
 
 /* パイプラインの開始点を表す特殊なレコード。処理関数内では無視すること */
-type originInput struct{}
+type Origin struct{}
 
-func (o originInput) Group() Group {
+func (o Origin) Group() Group {
 	return GroupString(na)
 }
 
-func (o originInput) Identifier() string {
+func (o Origin) Identifier() string {
 	return na
 }
 

--- a/reduce.go
+++ b/reduce.go
@@ -7,13 +7,45 @@ import (
 )
 
 // <group1, list(id1)> -> Reduce() -> list(<group2, id2>)
-type Reducer interface {
+// 利用者が実装する型
+type Reducer[I Record, O Record, G Group] interface {
+	Reduce(ctx context.Context, group G, inputs []I) ([]O, error)
+}
+
+// 内部処理で利用される、具体型を持ったinterface
+type reducer interface {
 	Reduce(ctx context.Context, group Group, inputs []Record) ([]Record, error)
+}
+
+// Reducerをラップしてreducerインターフェースを実装する型
+type reduceWrapper[I Record, O Record, G Group] struct {
+	reducer Reducer[I, O, G]
+}
+
+func (m *reduceWrapper[I, O, G]) Reduce(ctx context.Context, group Group, inputs []Record) ([]Record, error) {
+	g := group.(G)
+
+	var ins []I
+	for _, i := range inputs {
+		ins = append(ins, i.(I))
+	}
+
+	outs, err := m.reducer.Reduce(ctx, g, ins)
+	if err != nil {
+		return nil, err
+	}
+
+	var outputs []Record
+	for _, o := range outs {
+		outputs = append(outputs, o)
+	}
+
+	return outputs, nil
 }
 
 type reduceProcessor struct {
 	name            string
-	reducer         Reducer
+	reducer         reducer
 	maxParallel     int
 	abortIfAnyError bool
 }
@@ -22,10 +54,12 @@ type ReducerOption func(p *reduceProcessor)
 
 func (o ReducerOption) ReduceStageOption() {}
 
-func newReduceProcessor(name string, reducer Reducer, opts ...ReducerOption) *reduceProcessor {
+func newReduceProcessor[I Record, O Record, G Group](name string, reducer Reducer[I, O, G], opts ...ReducerOption) *reduceProcessor {
 	p := &reduceProcessor{
-		name:    name,
-		reducer: reducer,
+		name: name,
+		reducer: &reduceWrapper[I, O, G]{
+			reducer: reducer,
+		},
 	}
 
 	for _, opt := range opts {

--- a/stage.go
+++ b/stage.go
@@ -23,11 +23,11 @@ func Stage(pr Processor, opts ...PipelineStageOption) *PipelineStage {
 }
 
 // Mapper / Reducerを元にステージを組み立てるためのユーティリティ関数
-func MapStage(name string, mapper Mapper, opts ...PipelineStageOption) *PipelineStage {
+func MapStage[I Record, O Record](name string, mapper Mapper[I, O], opts ...PipelineStageOption) *PipelineStage {
 	return Stage(newMapProcessor(name, mapper), opts...)
 }
 
-func ReduceStage(name string, reducer Reducer, opts ...PipelineStageOption) *PipelineStage {
+func ReduceStage[I Record, O Record, G Group](name string, reducer Reducer[I, O, G], opts ...PipelineStageOption) *PipelineStage {
 	return Stage(newReduceProcessor(name, reducer), opts...)
 }
 

--- a/test_helper.go
+++ b/test_helper.go
@@ -55,7 +55,7 @@ func (m *testMapper) Map(ctx context.Context, input Record) ([]Record, error) {
 
 type testMapperAbort struct{}
 
-func (m *testMapperAbort) Map(ctx context.Context, input Record) ([]Record, error) {
+func (m *testMapperAbort) Map(ctx context.Context, input testRecord) ([]Record, error) {
 	outputs, err := (&testMapper{}).Map(ctx, input)
 	if err != nil {
 		return nil, AbortError(err)
@@ -68,7 +68,7 @@ type testReducer struct{}
 var errTestReducer = fmt.Errorf("test reducer error")
 
 // グループごとに件数を集計する
-func (r *testReducer) Reduce(ctx context.Context, group Group, inputs []Record) ([]Record, error) {
+func (r *testReducer) Reduce(ctx context.Context, group Group, inputs []testRecord) ([]testRecord, error) {
 	// Error
 	if strings.Contains(group.String(), "error") {
 		return nil, errTestReducer
@@ -80,27 +80,27 @@ func (r *testReducer) Reduce(ctx context.Context, group Group, inputs []Record) 
 			return nil, ctx.Err()
 		case <-time.After(10 * time.Second):
 		}
-		return []Record{}, nil
+		return []testRecord{}, nil
 	}
 
-	return []Record{
-		testRecord{group.String(), fmt.Sprintf("%d", len(inputs))},
+	return []testRecord{
+		{group.String(), fmt.Sprintf("%d", len(inputs))},
 	}, nil
 }
 
 type testGenerator struct{}
 
 // 適当に2つのレコードを生成する
-func (g *testGenerator) Map(ctx context.Context, input Record) ([]Record, error) {
-	return []Record{
-		testRecord{"group1", "id1"},
-		testRecord{"error", "id2"},
+func (g *testGenerator) Map(ctx context.Context, input Origin) ([]testRecord, error) {
+	return []testRecord{
+		{"group1", "id1"},
+		{"error", "id2"},
 	}, nil
 }
 
 type testReducerAbort struct{}
 
-func (m *testReducerAbort) Reduce(ctx context.Context, group Group, inputs []Record) ([]Record, error) {
+func (m *testReducerAbort) Reduce(ctx context.Context, group Group, inputs []testRecord) ([]testRecord, error) {
 	outputs, err := (&testReducer{}).Reduce(ctx, group, inputs)
 	if err != nil {
 		return nil, AbortError(err)
@@ -111,12 +111,12 @@ func (m *testReducerAbort) Reduce(ctx context.Context, group Group, inputs []Rec
 type testGeneratorTimeout struct{}
 
 // 適当に2つのレコードを生成する
-func (g *testGeneratorTimeout) Map(ctx context.Context, input Record) ([]Record, error) {
-	return []Record{
-		testRecord{"group1", "id1"},
-		testRecord{"error", "id2"},
-		testRecord{"timeout", "id3"},
-		testRecord{"group4", "id4"},
+func (g *testGeneratorTimeout) Map(ctx context.Context, input Origin) ([]testRecord, error) {
+	return []testRecord{
+		{"group1", "id1"},
+		{"error", "id2"},
+		{"timeout", "id3"},
+		{"group4", "id4"},
 	}, nil
 }
 
@@ -124,6 +124,6 @@ type testBrokenGenerator struct{}
 
 var errTestBrokenGenerator = errors.New("test broken generator error")
 
-func (g *testBrokenGenerator) Map(ctx context.Context, input Record) ([]Record, error) {
+func (g *testBrokenGenerator) Map(ctx context.Context, input Origin) ([]testRecord, error) {
 	return nil, AbortError(errTestBrokenGenerator)
 }


### PR DESCRIPTION
## What
現在のMapper / Reducerのインターフェースでは、利用者が定義する型がgo-pipelineパッケージのインターフェースに強く依存しており、pipelineに破壊的な変更が入ると影響範囲が広範に渡ってしまう。
また、利用者側で入出力の詰め替えを行う必要があったり、関数のシグネチャからどのようなデータが入ってくるのかが分かりにくいという不便さもあった。

これを防ぐため、Genericsを利用して、利用者では具体型を引数・返り値に持った型をMapper / Reducerとして定義できるようにする。

## Note
GroupCommitを返り値に含める場合、異なる型が混在することになるため返り値の型を具体型にすることはできなくなる。この問題は別のPRで対処する。