### PR TITLE
Group commit interface

### DIFF
--- a/map.go
+++ b/map.go
@@ -81,7 +81,7 @@ func (p *mapProcessor) Process(ctx context.Context, inputs <-chan Record, abort 
 	go func() {
 		for in := range inputs {
 			// GroupCommitは無視する
-			if _, ok := in.(groupCommit); ok {
+			if isGroupCommit(in) {
 				continue
 			}
 

--- a/map_test.go
+++ b/map_test.go
@@ -29,6 +29,7 @@ func Test_mapProcessor_Process(t *testing.T) {
 					testRecord{"group1", "id1"},
 					testRecord{"error", "id2"},
 					GroupCommit(GroupString("group2")),
+					testRecord{"group3", ""}, // group commit
 				},
 			},
 			want: []Output{
@@ -38,7 +39,7 @@ func Test_mapProcessor_Process(t *testing.T) {
 					Records: []Record{
 						testRecord{"group1_mapped", "id1_1"},
 						testRecord{"group1_mapped", "id1_2"},
-						GroupCommit(GroupString("group1_empty")),
+						testRecord{"group1_empty", ""},
 					},
 				},
 				{
@@ -74,7 +75,7 @@ func Test_mapProcessor_Process(t *testing.T) {
 					Records: []Record{
 						testRecord{"group1_mapped", "id1_1"},
 						testRecord{"group1_mapped", "id1_2"},
-						GroupCommit(GroupString("group1_empty")),
+						testRecord{"group1_empty", ""},
 					},
 				},
 				// 順番に処理されるので、timeout以降のものは全てtimeoutとして処理される
@@ -91,19 +92,7 @@ func Test_mapProcessor_Process(t *testing.T) {
 			},
 		},
 		{
-			name:   "abort",
-			mapper: newMapProcessor("test", &testMapperAbort{}),
-			args: args{
-				ctx: context.Background(),
-				inputs: []Record{
-					testRecord{"group1", "id1"},
-					testRecord{"error", "id3"},
-				},
-			},
-			wantErr: errTestMapper,
-		},
-		{
-			name: "abortIfAnyError (deprecated)",
+			name: "abort",
 			mapper: func() *mapProcessor {
 				pr := newMapProcessor("test", &testMapper{})
 				pr.SetAbortIfAnyError(true)
@@ -138,7 +127,7 @@ func Test_mapProcessor_Process(t *testing.T) {
 
 			close(abort)
 			if tt.wantErr != nil {
-				assert.ErrorIs(t, <-abort, tt.wantErr)
+				assert.ErrorIs(t, tt.wantErr, <-abort)
 				return
 			}
 

--- a/map_test.go
+++ b/map_test.go
@@ -92,7 +92,19 @@ func Test_mapProcessor_Process(t *testing.T) {
 			},
 		},
 		{
-			name: "abort",
+			name:   "abort",
+			mapper: newMapProcessor("test", &testMapperAbort{}),
+			args: args{
+				ctx: context.Background(),
+				inputs: []Record{
+					testRecord{"group1", "id1"},
+					testRecord{"error", "id3"},
+				},
+			},
+			wantErr: errTestMapper,
+		},
+		{
+			name: "abortIfAnyError (deprecated)",
 			mapper: func() *mapProcessor {
 				pr := newMapProcessor("test", &testMapper{})
 				pr.SetAbortIfAnyError(true)
@@ -127,7 +139,7 @@ func Test_mapProcessor_Process(t *testing.T) {
 
 			close(abort)
 			if tt.wantErr != nil {
-				assert.ErrorIs(t, tt.wantErr, <-abort)
+				assert.ErrorIs(t, <-abort, tt.wantErr)
 				return
 			}
 

--- a/process.go
+++ b/process.go
@@ -48,7 +48,7 @@ func (o Output) Summarized() SummarizedOutput {
 	var recordCount int
 	for _, r := range o.Records {
 		groups[r.Group().String()] = struct{}{}
-		if _, ok := r.(groupCommit); !ok {
+		if !isGroupCommit(r) {
 			recordCount++
 		}
 	}

--- a/record.go
+++ b/record.go
@@ -59,3 +59,17 @@ func (g groupCommit) Identifier() string {
 func EmptyGroup(g Group) groupCommit {
 	return groupCommit{g}
 }
+
+type GroupCommiter interface {
+	GroupCommit() bool
+}
+
+func isGroupCommit(record Record) bool {
+	if _, ok := record.(groupCommit); ok {
+		return true
+	}
+	if gc, ok := record.(GroupCommiter); ok && gc.GroupCommit() {
+		return true
+	}
+	return false
+}

--- a/record_test.go
+++ b/record_test.go
@@ -1,0 +1,53 @@
+package pipeline
+
+import "testing"
+
+func Test_isGroupCommit(t *testing.T) {
+	type args struct {
+		record Record
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "groupCommit struct",
+			args: args{
+				record: groupCommit{},
+			},
+			want: true,
+		},
+		{
+			name: "GroupCommit interface (true)",
+			args: args{
+				record: testRecord{"group", ""},
+			},
+			want: true,
+		},
+		{
+			name: "GroupCommit interface (false)",
+			args: args{
+				record: testRecord{"group", "id"},
+			},
+			want: false,
+		},
+		{
+			name: "normal record",
+			args: args{
+				record: func() Record {
+					var r Record
+					return r
+				}(),
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isGroupCommit(tt.args.record); got != tt.want {
+				t.Errorf("isGroupCommit() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/reduce.go
+++ b/reduce.go
@@ -119,7 +119,7 @@ func (p *reduceProcessor) Process(ctx context.Context, inputs <-chan Record, abo
 
 			// GroupCommitが流れてきた場合、すぐにgroupの処理を開始して、レコードをmapから削除する
 			// こうすることで、必要以上にメモリを使用しないようにする
-			if _, ok := in.(groupCommit); ok {
+			if isGroupCommit(in) {
 				groups[gr].done = true
 				inputs := groupedInputs[gr]
 				delete(groupedInputs, gr)

--- a/test_helper.go
+++ b/test_helper.go
@@ -24,17 +24,21 @@ func (r testRecord) Identifier() string {
 	return r.identifier
 }
 
+func (r testRecord) GroupCommit() bool {
+	return r.identifier == ""
+}
+
 var errTestMapper = errors.New("test mapper error")
 
 // 適当にsuffixつけて倍増させる
-func (m *testMapper) Map(ctx context.Context, input Record) ([]Record, error) {
+func (m *testMapper) Map(ctx context.Context, input testRecord) ([]testRecord, error) {
 	gr := input.Group().String()
 
 	if strings.Contains(gr, "group1") {
-		return []Record{
-			testRecord{gr + "_mapped", input.Identifier() + "_1"},
-			testRecord{gr + "_mapped", input.Identifier() + "_2"},
-			GroupCommit(GroupString(gr + "_empty")),
+		return []testRecord{
+			{gr + "_mapped", input.Identifier() + "_1"},
+			{gr + "_mapped", input.Identifier() + "_2"},
+			{gr + "_empty", ""},
 		}, nil
 	}
 	// Error
@@ -48,14 +52,14 @@ func (m *testMapper) Map(ctx context.Context, input Record) ([]Record, error) {
 			return nil, ctx.Err()
 		case <-time.After(10 * time.Second):
 		}
-		return []Record{}, nil
+		return []testRecord{}, nil
 	}
 	return nil, nil
 }
 
 type testMapperAbort struct{}
 
-func (m *testMapperAbort) Map(ctx context.Context, input testRecord) ([]Record, error) {
+func (m *testMapperAbort) Map(ctx context.Context, input testRecord) ([]testRecord, error) {
 	outputs, err := (&testMapper{}).Map(ctx, input)
 	if err != nil {
 		return nil, AbortError(err)


### PR DESCRIPTION
## What
https://github.com/cloudbase-inc/go-pipeline/pull/6 において、GroupCommitが出力に含まれる場合に、具体型を返り値に設定することができないという問題があった。
これを回避するために、具体型について `GroupCommiter` インターフェースを実装している場合に、この返り値を以ってGroupCommitとして判定できるようにする。これにより、返り値に具体型を使いながらGroupCommitを扱えるようにする。