### PR TITLE
feat: implement streamer

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ https://www.talend.com/jp/resources/what-is-mapreduce/
 `list(<group1, id1>) -> Stage() -> list(<group2, id2>)`
 
 実際の計算処理を実行する部分です。各ステージはレコードの集合を受け取り、何らかの処理を行なって加工したデータをレコードの集合として返す必要があります。
-MapReduce を参考に、現在 Mapper と Reducer という 2 つの処理アルゴリズムが実装されています。
+MapReduce を参考に、現在 Mapper と Reducer、および Streamer という 3 つの処理アルゴリズムが実装されています。
 
 #### マッパー (Mapper)
 
@@ -47,6 +47,12 @@ MapReduce を参考に、現在 Mapper と Reducer という 2 つの処理ア�
 `<group1, list(id1)> -> Reduce() -> list(<group2, id2>)`
 
 前段のレコードをグループ化し、各グループのレコードの集合に対して複数のレコードを返す関数として表現され、それらをグループ単位で並列に複数実行することで全体の結果を返します。主に後段の処理で加工されたデータを集約し集計や保存処理を行うために利用することができます。
+
+#### ストリーマー (Streamer)
+
+`channel(<group1, id1>) -> Streamer() -> channel(<group2, id2>)`
+
+レコードを逐次受け取り、逐次出力を返すようなストリーム処理を表現します。Mapper や Reducer での表現が難しい非同期処理を記述する場合に利用します。例えば、大量のデータを生成するような Mapper を実装する際、 代わりに Streamer で逐次結果を返すようにすることで、メモリ使用量を抑えられる他後続の処理を逐次開始することができパフォーマンスの向上も見込めます。
 
 ### アウトプット (Output)
 
@@ -118,9 +124,9 @@ func (v *VulnerabilityCount) Identifier() string    { return pipeline.Identifier
 
 </details>
 
-### 2. Mapper / Reducer を実装する
+### 2. Mapper / Reducer / Streamer を実装する
 
-Mapper / Reducer はそれぞれ次のようなインターフェースとして定義されています。これらを満たす型を実装します。
+Mapper / Reducer / Streamer はそれぞれ次のようなインターフェースとして定義されています。これらを満たす型を実装します。
 
 input には前段で出力されたレコードが入ります。型アサーションにより型を特定した上で必要な情報を参照します。
 
@@ -132,6 +138,10 @@ type Mapper[I Record, O Record] interface {
 type Reducer[I Record, O Record, G Group] interface {
 	Reduce(ctx context.Context, group G, inputs []I) ([]O, error)
 }
+
+type Streamer[I Record, O Record] interface {
+	Stream(ctx context.Context, inputs <-chan I) (<-chan O, <-chan error)
+}
 ```
 
 <details>
@@ -140,11 +150,21 @@ type Reducer[I Record, O Record, G Group] interface {
 ```go
 type RegionLister struct{}
 
-func (l *RegionLister) Map(ctx context.Context, _ pipeline.Origin) ([]*Region, error) {
-	return []*Region{
-		{Name: "ap-northeast-1"},
-		{Name: "us-west-1"},
-	}, nil
+func (l *RegionLister) Stream(ctx context.Context, inputs <-chan pipeline.Origin) (<-chan *Region, <-chan error) {
+	<-inputs
+
+	outs := make(chan *Region)
+	errs := make(chan error)
+
+	go func() {
+		defer close(outs)
+		defer close(errs)
+
+		outs <- &Region{Name: "ap-northeast-1"}
+		outs <- &Region{Name: "us-west-1"}
+	}()
+
+	return outs, errs
 }
 
 type VMLister struct{}
@@ -195,19 +215,18 @@ func (c *Counter) Reduce(ctx context.Context, group pipeline.Group, vulnerabilit
 
 ```go
 pp := pipeline.New(
-    pipeline.MapStage("RegionLister", &RegionLister{}),
+    pipeline.StreamStage("RegionLister", &RegionLister{}),
     pipeline.MapStage("VMLister", &VMLister{}, pipeline.StageTimeout(1*time.Second)),
     pipeline.MapStage("Scanner", &Scanner{}, pipeline.StageMaxParallel(3)),
     pipeline.ReduceStage("Counter", &Counter{}, pipeline.StageAbortIfAnyError(true)),
 )
 ```
 
-MapStage もしくは ReduceStage を使って、定義した Mapper や Reducer をパイプラインに組み込むことができます。
+`(Mapper|Reducer|Streamer)Stage()` を使って、定義した処理をパイプラインに組み込むことができます。
 またオプション引数で以下の値を設定できます。
 
 - `StageTimeout(d time.Duration)`: ステージ単位のタイムアウト。タイムアウト前に正常に完了したレコードは後続のステージに渡されそのまま実行されていきます。
-- `StageMaxParallel(n int)`: 並列実行数の上限を指定します。Mapper の場合はレコード、Reducer の場合はグループの数が最大の並列数になります。
-- `StageAbortIfAnyError(v bool)`: `true` に設定した場合、実行されているワーカーのいずれかでエラーが発生したらクリティカルなエラーとして全体の処理を中止します。データの保存など、失敗が許容されないクリティカルなステージに対して有効化してください。
+- `StageMaxParallel(n int)`: 並列実行数の上限を指定します。Mapper の場合はレコード、Reducer の場合はグループの数が最大の並列数になります。（StreamStage では利用不可）
 
 ### 4. Pipeline を実行する
 

--- a/examples/main.go
+++ b/examples/main.go
@@ -27,11 +27,21 @@ func (r *Region) Identifier() string    { return r.Name }
 
 type RegionLister struct{}
 
-func (l *RegionLister) Map(ctx context.Context, _ pipeline.Origin) ([]*Region, error) {
-	return []*Region{
-		{Name: "ap-northeast-1"},
-		{Name: "us-west-1"},
-	}, nil
+func (l *RegionLister) Stream(ctx context.Context, inputs <-chan pipeline.Origin) (<-chan *Region, <-chan error) {
+	<-inputs
+
+	outs := make(chan *Region)
+	errs := make(chan error)
+
+	go func() {
+		defer close(outs)
+		defer close(errs)
+
+		outs <- &Region{Name: "ap-northeast-1"}
+		outs <- &Region{Name: "us-west-1"}
+	}()
+
+	return outs, errs
 }
 
 type Instance struct {
@@ -102,7 +112,7 @@ func (c *Counter) Reduce(ctx context.Context, group pipeline.Group, vulnerabilit
 
 func main() {
 	pp := pipeline.New(
-		pipeline.MapStage("RegionLister", &RegionLister{}),
+		pipeline.StreamStage("RegionLister", &RegionLister{}),
 		pipeline.MapStage("VMLister", &VMLister{}, pipeline.StageTimeout(1*time.Second)),
 		pipeline.MapStage("Scanner", &Scanner{}, pipeline.StageMaxParallel(3)),
 		pipeline.ReduceStage("Counter", &Counter{}, pipeline.StageAbortIfAnyError(true)),

--- a/map.go
+++ b/map.go
@@ -22,10 +22,10 @@ type mapWrapper[I Record, O Record] struct {
 	mapper Mapper[I, O]
 }
 
-func (m *mapWrapper[I, O]) Map(ctx context.Context, input Record) ([]Record, error) {
+func (w *mapWrapper[I, O]) Map(ctx context.Context, input Record) ([]Record, error) {
 	i := input.(I)
 
-	outs, err := m.mapper.Map(ctx, i)
+	outs, err := w.mapper.Map(ctx, i)
 	if err != nil {
 		return nil, err
 	}

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -30,6 +31,7 @@ func TestPipeline_Execute(t *testing.T) {
 					MapStage("Generator", &testGenerator{}),
 					MapStage("Map1", &testMapper{}),
 					MapStage("Map2", &testMapper{}),
+					StreamStage("Stream", &testStreamer{}),
 					ReduceStage("Reduce", &testReducer{}),
 				},
 			},
@@ -85,6 +87,47 @@ func TestPipeline_Execute(t *testing.T) {
 							Status:      OutputStatusSuccess,
 							RecordCount: 2,
 							GroupCount:  2,
+						},
+					},
+				},
+				{
+					Name: "Stream",
+					Type: ProcessorTypeStream,
+					Outputs: []SummarizedOutput{
+						{
+							Status: OutputStatusError,
+							Err:    errors.New("something wrong"),
+						},
+						{
+							Status:      OutputStatusSuccess,
+							RecordCount: 1,
+							GroupCount:  1,
+						},
+						{
+							Status:      OutputStatusSuccess,
+							RecordCount: 1,
+							GroupCount:  1,
+						},
+						{
+							Status:      OutputStatusSuccess,
+							RecordCount: 1,
+							GroupCount:  1,
+						},
+						{
+							Status:      OutputStatusSuccess,
+							RecordCount: 1,
+							GroupCount:  1,
+						},
+						// Group Commit
+						{
+							Status:      OutputStatusSuccess,
+							RecordCount: 0,
+							GroupCount:  1,
+						},
+						{
+							Status:      OutputStatusSuccess,
+							RecordCount: 0,
+							GroupCount:  1,
 						},
 					},
 				},

--- a/process.go
+++ b/process.go
@@ -19,6 +19,7 @@ type ProcessorType string
 const (
 	ProcessorTypeMap    ProcessorType = "Map"
 	ProcessorTypeReduce ProcessorType = "Reduce"
+	ProcessorTypeStream ProcessorType = "Stream"
 )
 
 type OutputStatus string

--- a/reduce.go
+++ b/reduce.go
@@ -22,7 +22,7 @@ type reduceWrapper[I Record, O Record, G Group] struct {
 	reducer Reducer[I, O, G]
 }
 
-func (m *reduceWrapper[I, O, G]) Reduce(ctx context.Context, group Group, inputs []Record) ([]Record, error) {
+func (w *reduceWrapper[I, O, G]) Reduce(ctx context.Context, group Group, inputs []Record) ([]Record, error) {
 	g := group.(G)
 
 	var ins []I
@@ -30,7 +30,7 @@ func (m *reduceWrapper[I, O, G]) Reduce(ctx context.Context, group Group, inputs
 		ins = append(ins, i.(I))
 	}
 
-	outs, err := m.reducer.Reduce(ctx, g, ins)
+	outs, err := w.reducer.Reduce(ctx, g, ins)
 	if err != nil {
 		return nil, err
 	}

--- a/stage.go
+++ b/stage.go
@@ -31,6 +31,10 @@ func ReduceStage[I Record, O Record, G Group](name string, reducer Reducer[I, O,
 	return Stage(newReduceProcessor(name, reducer), opts...)
 }
 
+func StreamStage[I Record, O Record](name string, streamer Streamer[I, O]) *PipelineStage {
+	return Stage(newStreamProcessor(name, streamer))
+}
+
 /* 実行時オプション */
 func StageMaxParallel(max int) PipelineStageOption {
 	return func(s *PipelineStage) {

--- a/stream.go
+++ b/stream.go
@@ -1,0 +1,127 @@
+package pipeline
+
+import (
+	"context"
+	"sync"
+)
+
+// channel(<group1, id1>) -> Streamer() -> channel(<group2, id2>)
+// 利用者が実装する型
+type Streamer[I Record, O Record] interface {
+	Stream(ctx context.Context, inputs <-chan I) (<-chan O, <-chan error)
+}
+
+// 内部処理で利用される、具体型を持ったinterface
+type streamer interface {
+	Stream(ctx context.Context, inputs <-chan Record) (<-chan Record, <-chan error)
+}
+
+// Reducerをラップしてreducerインターフェースを実装する型
+type streamWrapper[I Record, O Record] struct {
+	streamer Streamer[I, O]
+}
+
+func (w *streamWrapper[I, O]) Stream(ctx context.Context, inputs <-chan Record) (<-chan Record, <-chan error) {
+	ins := make(chan I)
+	go func() {
+		for i := range inputs {
+			ins <- i.(I)
+		}
+		close(ins)
+	}()
+
+	outs, errs := w.streamer.Stream(ctx, ins)
+
+	outputs := make(chan Record)
+	go func() {
+		defer close(outputs)
+		for o := range outs {
+			outputs <- o
+		}
+	}()
+
+	return outputs, errs
+}
+
+type streamProcessor struct {
+	name     string
+	streamer streamer
+}
+
+func newStreamProcessor[I Record, O Record](name string, streamer Streamer[I, O]) *streamProcessor {
+	return &streamProcessor{
+		name:     name,
+		streamer: &streamWrapper[I, O]{streamer: streamer},
+	}
+}
+
+func (p *streamProcessor) SetMaxParallel(max int) {
+	panic("max parallel is not supported for stream")
+}
+
+func (p *streamProcessor) SetAbortIfAnyError(value bool) {
+	panic("abortIfAnyError is not supported for stream")
+}
+
+func (p *streamProcessor) Name() string {
+	return p.name
+}
+
+func (p *streamProcessor) Type() ProcessorType {
+	return ProcessorTypeStream
+}
+
+func (p *streamProcessor) Process(ctx context.Context, inputs <-chan Record, abort chan<- error) <-chan Output {
+	outputs := make(chan Output)
+
+	go func() {
+		defer close(outputs)
+
+		outs, errs := p.streamer.Stream(ctx, inputs)
+
+		wg := sync.WaitGroup{}
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for o := range outs {
+				outputs <- Output{
+					Status:  OutputStatusSuccess,
+					Records: []Record{o},
+				}
+			}
+		}()
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for err := range errs {
+				if IsAbortError(err) {
+					abort <- err
+					return
+				}
+
+				outputs <- Output{
+					Status: OutputStatusError,
+					Err:    err,
+				}
+			}
+		}()
+
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+
+			wg.Wait()
+			done <- struct{}{}
+		}()
+
+		select {
+		case <-ctx.Done():
+			abort <- ctx.Err()
+		case <-done:
+		}
+	}()
+
+	return outputs
+}

--- a/stream.go
+++ b/stream.go
@@ -98,7 +98,7 @@ func (p *streamProcessor) Process(ctx context.Context, inputs <-chan Record, abo
 			for err := range errs {
 				if IsAbortError(err) {
 					abort <- err
-					continue
+					return
 				}
 
 				outputs <- Output{

--- a/stream.go
+++ b/stream.go
@@ -98,7 +98,7 @@ func (p *streamProcessor) Process(ctx context.Context, inputs <-chan Record, abo
 			for err := range errs {
 				if IsAbortError(err) {
 					abort <- err
-					return
+					continue
 				}
 
 				outputs <- Output{

--- a/stream_test.go
+++ b/stream_test.go
@@ -1,0 +1,115 @@
+package pipeline
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_streamProcessor_Process(t *testing.T) {
+	type args struct {
+		ctx    context.Context
+		inputs []Record
+	}
+	tests := []struct {
+		name     string
+		streamer *streamProcessor
+		args     args
+		want     []Output
+		wantErr  error
+	}{
+		{
+			name:     "happy path",
+			streamer: newStreamProcessor("test", &testStreamer{}),
+			args: args{
+				ctx: context.Background(),
+				inputs: []Record{
+					testRecord{"group1", "id1"},
+					testRecord{"group1", "id2"},
+					GroupCommit(GroupString("group1")),
+					testRecord{"group2", "id3"},
+				},
+			},
+			want: []Output{
+				{
+					Status: OutputStatusError,
+					Err:    errors.New("something wrong"),
+				},
+				{
+					Status:  OutputStatusSuccess,
+					Records: []Record{testRecord{"group1", "id1"}},
+				},
+				{
+					Status:  OutputStatusSuccess,
+					Records: []Record{testRecord{"group1", "id2"}},
+				},
+				{
+					Status:  OutputStatusSuccess,
+					Records: []Record{GroupCommit(GroupString("group1"))},
+				},
+				{
+					Status:  OutputStatusSuccess,
+					Records: []Record{testRecord{"group2", "id3"}},
+				},
+			},
+		},
+		{
+			name:     "timeout",
+			streamer: newStreamProcessor("test", &testStreamerTimeout{}),
+			args: args{
+				ctx: func() context.Context {
+					ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+					t.Cleanup(cancel)
+					return ctx
+				}(),
+				inputs: []Record{
+					testRecord{"timeout1", "id1"},
+					testRecord{"timeout2", "id2"},
+				},
+			},
+			wantErr: context.DeadlineExceeded,
+		},
+		{
+			name:     "abort",
+			streamer: newStreamProcessor("test", &testStreamerFatalError{}),
+			args: args{
+				ctx: context.Background(),
+				inputs: []Record{
+					testRecord{"group1", "id1"},
+					testRecord{"group2", "id2"},
+					testRecord{"error", "id3"},
+				},
+			},
+			wantErr: errStreamFatal,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inputs := make(chan Record)
+			go func() {
+				for _, in := range tt.args.inputs {
+					inputs <- in
+				}
+				close(inputs)
+			}()
+
+			abort := make(chan error, 1)
+
+			outputs := []Output{}
+			for o := range tt.streamer.Process(tt.args.ctx, inputs, abort) {
+				outputs = append(outputs, o)
+			}
+
+			close(abort)
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, <-abort, tt.wantErr)
+				return
+			}
+
+			assert.ElementsMatch(t, tt.want, outputs)
+		})
+	}
+}

--- a/test_helper.go
+++ b/test_helper.go
@@ -127,3 +127,68 @@ var errTestBrokenGenerator = errors.New("test broken generator error")
 func (g *testBrokenGenerator) Map(ctx context.Context, input Origin) ([]testRecord, error) {
 	return nil, AbortError(errTestBrokenGenerator)
 }
+
+type testStreamer struct{}
+
+func (s *testStreamer) Stream(ctx context.Context, inputs <-chan Record) (<-chan Record, <-chan error) {
+	outs := make(chan Record)
+	errs := make(chan error)
+
+	go func() {
+		defer close(outs)
+		defer close(errs)
+
+		// errorを1件発生させる
+		errs <- errors.New("something wrong")
+
+		// inputをそのまま流す
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case input, ok := <-inputs:
+				if !ok {
+					return
+				}
+				outs <- input
+			}
+		}
+	}()
+
+	return outs, errs
+}
+
+var errStreamFatal = errors.New("fatal stream error")
+
+type testStreamerFatalError struct{}
+
+func (s *testStreamerFatalError) Stream(ctx context.Context, inputs <-chan Record) (<-chan Record, <-chan error) {
+	outs := make(chan Record)
+	errs := make(chan error)
+
+	go func() {
+		defer close(outs)
+		defer close(errs)
+
+		// クリティカルなエラーを返す
+		errs <- AbortError(errStreamFatal)
+	}()
+
+	return outs, errs
+}
+
+type testStreamerTimeout struct{}
+
+func (s *testStreamerTimeout) Stream(ctx context.Context, inputs <-chan Record) (<-chan Record, <-chan error) {
+	outs := make(chan Record)
+	errs := make(chan error)
+
+	go func() {
+		defer close(outs)
+		defer close(errs)
+
+		<-time.After(10 * time.Second)
+	}()
+
+	return outs, errs
+}


### PR DESCRIPTION
既存のMapperでは返り値を配列として返すため、1つの入力に対して出力が大量になる場合に、それらが全てメモリに乗ってしまい使用量が膨大になる点、全ての入力を待ち受けてからでないと後続の処理が開始できないという問題があった。
これを解消するために、MapperやReducerよりも柔軟な処理を実現できるStreamerインターフェースを定義する。

```go
type Streamer[I Record, O Record] interface {
	Stream(ctx context.Context, inputs <-chan I) (<-chan O, <-chan error)
}
```

Streamerでは、入力をchannelとして受け取り、それに対する出力を逐次的に返す。これにより、入力を順次処理しながら出力を後続に流していくという処理が実現できる。
エラーはchan errorに対して流す。MapperやReducerと同様に、`pipeline.AbortError` が返った場合に全体の処理を中断し、それ以外の場合には部分的なエラーとしての計測に留める。