### PR TITLE
feat: add groupCount / recordCount

### DIFF
--- a/pipeline.go
+++ b/pipeline.go
@@ -57,10 +57,18 @@ func (p *Pipeline) Execute(ctx context.Context) (outputs []Record, stages []Stag
 
 			pr := stage.processor
 
+			groups := make(map[string]struct{})
+			recordCount := 0
+
 			summarizedOutputs := []SummarizedOutput{}
 			for o := range pr.Process(ctx, stageInputs[i], abort) {
 				// 前段のoutputを、次のinputに入れる
 				for _, r := range o.Records {
+					groups[r.Group().String()] = struct{}{}
+					if !isGroupCommit(r) {
+						recordCount++
+					}
+
 					stageInputs[i+1] <- r
 				}
 				summarizedOutputs = append(summarizedOutputs, o.Summarized())
@@ -69,9 +77,11 @@ func (p *Pipeline) Execute(ctx context.Context) (outputs []Record, stages []Stag
 			// 前段のinputsがcloseしない限り次のstageが終わることはないので、
 			// ここは排他制御する必要はない
 			stages = append(stages, StageExecution{
-				Name:    pr.Name(),
-				Type:    pr.Type(),
-				Outputs: summarizedOutputs,
+				Name:        pr.Name(),
+				Type:        pr.Type(),
+				GroupCount:  len(groups),
+				RecordCount: recordCount,
+				Outputs:     summarizedOutputs,
 			})
 
 			close(stageInputs[i+1])

--- a/pipeline.go
+++ b/pipeline.go
@@ -58,17 +58,12 @@ func (p *Pipeline) Execute(ctx context.Context) (outputs []Record, stages []Stag
 			pr := stage.processor
 
 			groups := make(map[string]struct{})
-			recordCount := 0
 
 			summarizedOutputs := []SummarizedOutput{}
 			for o := range pr.Process(ctx, stageInputs[i], abort) {
 				// 前段のoutputを、次のinputに入れる
 				for _, r := range o.Records {
 					groups[r.Group().String()] = struct{}{}
-					if !isGroupCommit(r) {
-						recordCount++
-					}
-
 					stageInputs[i+1] <- r
 				}
 				summarizedOutputs = append(summarizedOutputs, o.Summarized())
@@ -77,11 +72,10 @@ func (p *Pipeline) Execute(ctx context.Context) (outputs []Record, stages []Stag
 			// 前段のinputsがcloseしない限り次のstageが終わることはないので、
 			// ここは排他制御する必要はない
 			stages = append(stages, StageExecution{
-				Name:        pr.Name(),
-				Type:        pr.Type(),
-				GroupCount:  len(groups),
-				RecordCount: recordCount,
-				Outputs:     summarizedOutputs,
+				Name:       pr.Name(),
+				Type:       pr.Type(),
+				GroupCount: len(groups),
+				Outputs:    summarizedOutputs,
 			})
 
 			close(stageInputs[i+1])

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -44,30 +44,26 @@ func TestPipeline_Execute(t *testing.T) {
 			},
 			wantStages: []StageExecution{
 				{
-					Name:        "Generator",
-					Type:        ProcessorTypeMap,
-					GroupCount:  2,
-					RecordCount: 2,
+					Name:       "Generator",
+					Type:       ProcessorTypeMap,
+					GroupCount: 2,
 					Outputs: []SummarizedOutput{
 						{
 							Unit:        "*/*",
 							Status:      OutputStatusSuccess,
 							RecordCount: 2,
-							GroupCount:  2,
 						},
 					},
 				},
 				{
-					Name:        "Map1",
-					Type:        ProcessorTypeMap,
-					GroupCount:  2,
-					RecordCount: 2,
+					Name:       "Map1",
+					Type:       ProcessorTypeMap,
+					GroupCount: 2,
 					Outputs: []SummarizedOutput{
 						{
 							Unit:        "group1/id1",
 							Status:      OutputStatusSuccess,
 							RecordCount: 2,
-							GroupCount:  2,
 						},
 						{
 							Unit:   "error/id2",
@@ -77,30 +73,26 @@ func TestPipeline_Execute(t *testing.T) {
 					},
 				},
 				{
-					Name:        "Map2",
-					Type:        ProcessorTypeMap,
-					GroupCount:  2,
-					RecordCount: 4,
+					Name:       "Map2",
+					Type:       ProcessorTypeMap,
+					GroupCount: 2,
 					Outputs: []SummarizedOutput{
 						{
 							Unit:        "group1_mapped/id1_1",
 							Status:      OutputStatusSuccess,
 							RecordCount: 2,
-							GroupCount:  2,
 						},
 						{
 							Unit:        "group1_mapped/id1_2",
 							Status:      OutputStatusSuccess,
 							RecordCount: 2,
-							GroupCount:  2,
 						},
 					},
 				},
 				{
-					Name:        "Stream",
-					Type:        ProcessorTypeStream,
-					GroupCount:  2,
-					RecordCount: 4,
+					Name:       "Stream",
+					Type:       ProcessorTypeStream,
+					GroupCount: 2,
 					Outputs: []SummarizedOutput{
 						{
 							Status: OutputStatusError,
@@ -109,53 +101,44 @@ func TestPipeline_Execute(t *testing.T) {
 						{
 							Status:      OutputStatusSuccess,
 							RecordCount: 1,
-							GroupCount:  1,
 						},
 						{
 							Status:      OutputStatusSuccess,
 							RecordCount: 1,
-							GroupCount:  1,
 						},
 						{
 							Status:      OutputStatusSuccess,
 							RecordCount: 1,
-							GroupCount:  1,
 						},
 						{
 							Status:      OutputStatusSuccess,
 							RecordCount: 1,
-							GroupCount:  1,
 						},
 						// Group Commit
 						{
 							Status:      OutputStatusSuccess,
 							RecordCount: 0,
-							GroupCount:  1,
 						},
 						{
 							Status:      OutputStatusSuccess,
 							RecordCount: 0,
-							GroupCount:  1,
 						},
 					},
 				},
 				{
-					Name:        "Reduce",
-					Type:        ProcessorTypeReduce,
-					GroupCount:  2,
-					RecordCount: 2,
+					Name:       "Reduce",
+					Type:       ProcessorTypeReduce,
+					GroupCount: 2,
 					Outputs: []SummarizedOutput{
 						{
 							Unit:        "group1_mapped_mapped",
 							Status:      OutputStatusSuccess,
 							RecordCount: 1,
-							GroupCount:  1,
 						},
 						{
 							Unit:        "group1_mapped_empty",
 							Status:      OutputStatusSuccess,
 							RecordCount: 1,
-							GroupCount:  1,
 						},
 					},
 				},
@@ -183,30 +166,26 @@ func TestPipeline_Execute(t *testing.T) {
 			},
 			wantStages: []StageExecution{
 				{
-					Name:        "Generator",
-					Type:        ProcessorTypeMap,
-					GroupCount:  4,
-					RecordCount: 4,
+					Name:       "Generator",
+					Type:       ProcessorTypeMap,
+					GroupCount: 4,
 					Outputs: []SummarizedOutput{
 						{
 							Unit:        "*/*",
 							Status:      OutputStatusSuccess,
 							RecordCount: 4,
-							GroupCount:  4,
 						},
 					},
 				},
 				{
-					Name:        "Map1",
-					Type:        ProcessorTypeMap,
-					GroupCount:  2,
-					RecordCount: 2,
+					Name:       "Map1",
+					Type:       ProcessorTypeMap,
+					GroupCount: 2,
 					Outputs: []SummarizedOutput{
 						{
 							Unit:        "group1/id1",
 							Status:      OutputStatusSuccess,
 							RecordCount: 2,
-							GroupCount:  2,
 						},
 						{
 							Unit:   "error/id2",
@@ -227,31 +206,27 @@ func TestPipeline_Execute(t *testing.T) {
 				},
 				// mapperは前段で出力されたものを順次処理していくため、timeoutが発生したかどうかに関係なく処理を続行することができる
 				{
-					Name:        "Map2",
-					Type:        ProcessorTypeMap,
-					GroupCount:  2,
-					RecordCount: 4,
+					Name:       "Map2",
+					Type:       ProcessorTypeMap,
+					GroupCount: 2,
 					Outputs: []SummarizedOutput{
 						{
 							Unit:        "group1_mapped/id1_1",
 							Status:      OutputStatusSuccess,
 							RecordCount: 2,
-							GroupCount:  2,
 						},
 						{
 							Unit:        "group1_mapped/id1_2",
 							Status:      OutputStatusSuccess,
 							RecordCount: 2,
-							GroupCount:  2,
 						},
 					},
 				},
 				// GroupCommitによって先にコミットされたグループのみ、正常に処理される
 				{
-					Name:        "Reduce",
-					Type:        ProcessorTypeReduce,
-					GroupCount:  1,
-					RecordCount: 1,
+					Name:       "Reduce",
+					Type:       ProcessorTypeReduce,
+					GroupCount: 1,
 					Outputs: []SummarizedOutput{
 						{
 							Unit:   "group1_mapped_mapped",
@@ -262,7 +237,6 @@ func TestPipeline_Execute(t *testing.T) {
 							Unit:        "group1_mapped_empty",
 							Status:      OutputStatusSuccess,
 							RecordCount: 1,
-							GroupCount:  1,
 						},
 					},
 				},
@@ -287,30 +261,26 @@ func TestPipeline_Execute(t *testing.T) {
 			},
 			wantStages: []StageExecution{
 				{
-					Name:        "Generator",
-					Type:        ProcessorTypeMap,
-					GroupCount:  4,
-					RecordCount: 4,
+					Name:       "Generator",
+					Type:       ProcessorTypeMap,
+					GroupCount: 4,
 					Outputs: []SummarizedOutput{
 						{
 							Unit:        "*/*",
 							Status:      OutputStatusSuccess,
 							RecordCount: 4,
-							GroupCount:  4,
 						},
 					},
 				},
 				{
-					Name:        "Map1",
-					Type:        ProcessorTypeMap,
-					GroupCount:  2,
-					RecordCount: 2,
+					Name:       "Map1",
+					Type:       ProcessorTypeMap,
+					GroupCount: 2,
 					Outputs: []SummarizedOutput{
 						{
 							Unit:        "group1/id1",
 							Status:      OutputStatusSuccess,
 							RecordCount: 2,
-							GroupCount:  2,
 						},
 						{
 							Unit:   "error/id2",
@@ -331,42 +301,36 @@ func TestPipeline_Execute(t *testing.T) {
 				},
 				// Map1はステージ単位でタイムアウトになるが、後続の処理は正常に完了する
 				{
-					Name:        "Map2",
-					Type:        ProcessorTypeMap,
-					GroupCount:  2,
-					RecordCount: 4,
+					Name:       "Map2",
+					Type:       ProcessorTypeMap,
+					GroupCount: 2,
 					Outputs: []SummarizedOutput{
 						{
 							Unit:        "group1_mapped/id1_1",
 							Status:      OutputStatusSuccess,
 							RecordCount: 2,
-							GroupCount:  2,
 						},
 						{
 							Unit:        "group1_mapped/id1_2",
 							Status:      OutputStatusSuccess,
 							RecordCount: 2,
-							GroupCount:  2,
 						},
 					},
 				},
 				{
-					Name:        "Reduce",
-					Type:        ProcessorTypeReduce,
-					GroupCount:  2,
-					RecordCount: 2,
+					Name:       "Reduce",
+					Type:       ProcessorTypeReduce,
+					GroupCount: 2,
 					Outputs: []SummarizedOutput{
 						{
 							Unit:        "group1_mapped_mapped",
 							Status:      OutputStatusSuccess,
 							RecordCount: 1,
-							GroupCount:  1,
 						},
 						{
 							Unit:        "group1_mapped_empty",
 							Status:      OutputStatusSuccess,
 							RecordCount: 1,
-							GroupCount:  1,
 						},
 					},
 				},
@@ -415,7 +379,6 @@ func TestPipeline_Execute(t *testing.T) {
 				assert.Equal(t, expected.Name, stages[i].Name)
 				assert.Equal(t, expected.Type, stages[i].Type)
 				assert.Equal(t, expected.GroupCount, stages[i].GroupCount)
-				assert.Equal(t, expected.RecordCount, stages[i].RecordCount)
 				assert.ElementsMatch(t, expected.Outputs, stages[i].Outputs)
 			}
 		})

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -44,8 +44,10 @@ func TestPipeline_Execute(t *testing.T) {
 			},
 			wantStages: []StageExecution{
 				{
-					Name: "Generator",
-					Type: ProcessorTypeMap,
+					Name:        "Generator",
+					Type:        ProcessorTypeMap,
+					GroupCount:  2,
+					RecordCount: 2,
 					Outputs: []SummarizedOutput{
 						{
 							Unit:        "*/*",
@@ -56,8 +58,10 @@ func TestPipeline_Execute(t *testing.T) {
 					},
 				},
 				{
-					Name: "Map1",
-					Type: ProcessorTypeMap,
+					Name:        "Map1",
+					Type:        ProcessorTypeMap,
+					GroupCount:  2,
+					RecordCount: 2,
 					Outputs: []SummarizedOutput{
 						{
 							Unit:        "group1/id1",
@@ -73,8 +77,10 @@ func TestPipeline_Execute(t *testing.T) {
 					},
 				},
 				{
-					Name: "Map2",
-					Type: ProcessorTypeMap,
+					Name:        "Map2",
+					Type:        ProcessorTypeMap,
+					GroupCount:  2,
+					RecordCount: 4,
 					Outputs: []SummarizedOutput{
 						{
 							Unit:        "group1_mapped/id1_1",
@@ -91,8 +97,10 @@ func TestPipeline_Execute(t *testing.T) {
 					},
 				},
 				{
-					Name: "Stream",
-					Type: ProcessorTypeStream,
+					Name:        "Stream",
+					Type:        ProcessorTypeStream,
+					GroupCount:  2,
+					RecordCount: 4,
 					Outputs: []SummarizedOutput{
 						{
 							Status: OutputStatusError,
@@ -132,8 +140,10 @@ func TestPipeline_Execute(t *testing.T) {
 					},
 				},
 				{
-					Name: "Reduce",
-					Type: ProcessorTypeReduce,
+					Name:        "Reduce",
+					Type:        ProcessorTypeReduce,
+					GroupCount:  2,
+					RecordCount: 2,
 					Outputs: []SummarizedOutput{
 						{
 							Unit:        "group1_mapped_mapped",
@@ -173,8 +183,10 @@ func TestPipeline_Execute(t *testing.T) {
 			},
 			wantStages: []StageExecution{
 				{
-					Name: "Generator",
-					Type: ProcessorTypeMap,
+					Name:        "Generator",
+					Type:        ProcessorTypeMap,
+					GroupCount:  4,
+					RecordCount: 4,
 					Outputs: []SummarizedOutput{
 						{
 							Unit:        "*/*",
@@ -185,8 +197,10 @@ func TestPipeline_Execute(t *testing.T) {
 					},
 				},
 				{
-					Name: "Map1",
-					Type: ProcessorTypeMap,
+					Name:        "Map1",
+					Type:        ProcessorTypeMap,
+					GroupCount:  2,
+					RecordCount: 2,
 					Outputs: []SummarizedOutput{
 						{
 							Unit:        "group1/id1",
@@ -213,8 +227,10 @@ func TestPipeline_Execute(t *testing.T) {
 				},
 				// mapperは前段で出力されたものを順次処理していくため、timeoutが発生したかどうかに関係なく処理を続行することができる
 				{
-					Name: "Map2",
-					Type: ProcessorTypeMap,
+					Name:        "Map2",
+					Type:        ProcessorTypeMap,
+					GroupCount:  2,
+					RecordCount: 4,
 					Outputs: []SummarizedOutput{
 						{
 							Unit:        "group1_mapped/id1_1",
@@ -232,8 +248,10 @@ func TestPipeline_Execute(t *testing.T) {
 				},
 				// GroupCommitによって先にコミットされたグループのみ、正常に処理される
 				{
-					Name: "Reduce",
-					Type: ProcessorTypeReduce,
+					Name:        "Reduce",
+					Type:        ProcessorTypeReduce,
+					GroupCount:  1,
+					RecordCount: 1,
 					Outputs: []SummarizedOutput{
 						{
 							Unit:   "group1_mapped_mapped",
@@ -269,8 +287,10 @@ func TestPipeline_Execute(t *testing.T) {
 			},
 			wantStages: []StageExecution{
 				{
-					Name: "Generator",
-					Type: ProcessorTypeMap,
+					Name:        "Generator",
+					Type:        ProcessorTypeMap,
+					GroupCount:  4,
+					RecordCount: 4,
 					Outputs: []SummarizedOutput{
 						{
 							Unit:        "*/*",
@@ -281,8 +301,10 @@ func TestPipeline_Execute(t *testing.T) {
 					},
 				},
 				{
-					Name: "Map1",
-					Type: ProcessorTypeMap,
+					Name:        "Map1",
+					Type:        ProcessorTypeMap,
+					GroupCount:  2,
+					RecordCount: 2,
 					Outputs: []SummarizedOutput{
 						{
 							Unit:        "group1/id1",
@@ -309,8 +331,10 @@ func TestPipeline_Execute(t *testing.T) {
 				},
 				// Map1はステージ単位でタイムアウトになるが、後続の処理は正常に完了する
 				{
-					Name: "Map2",
-					Type: ProcessorTypeMap,
+					Name:        "Map2",
+					Type:        ProcessorTypeMap,
+					GroupCount:  2,
+					RecordCount: 4,
 					Outputs: []SummarizedOutput{
 						{
 							Unit:        "group1_mapped/id1_1",
@@ -327,8 +351,10 @@ func TestPipeline_Execute(t *testing.T) {
 					},
 				},
 				{
-					Name: "Reduce",
-					Type: ProcessorTypeReduce,
+					Name:        "Reduce",
+					Type:        ProcessorTypeReduce,
+					GroupCount:  2,
+					RecordCount: 2,
 					Outputs: []SummarizedOutput{
 						{
 							Unit:        "group1_mapped_mapped",
@@ -388,6 +414,8 @@ func TestPipeline_Execute(t *testing.T) {
 			for i, expected := range tt.wantStages {
 				assert.Equal(t, expected.Name, stages[i].Name)
 				assert.Equal(t, expected.Type, stages[i].Type)
+				assert.Equal(t, expected.GroupCount, stages[i].GroupCount)
+				assert.Equal(t, expected.RecordCount, stages[i].RecordCount)
 				assert.ElementsMatch(t, expected.Outputs, stages[i].Outputs)
 			}
 		})

--- a/process.go
+++ b/process.go
@@ -40,7 +40,6 @@ type SummarizedOutput struct {
 	Unit        string
 	Status      OutputStatus
 	RecordCount int
-	GroupCount  int
 	Err         error
 }
 
@@ -58,7 +57,6 @@ func (o Output) Summarized() SummarizedOutput {
 		Unit:        o.Unit,
 		Status:      o.Status,
 		RecordCount: recordCount,
-		GroupCount:  len(groups),
 		Err:         o.Err,
 	}
 }

--- a/process_test.go
+++ b/process_test.go
@@ -27,7 +27,6 @@ func TestOutput_Summarized(t *testing.T) {
 				Unit:        "unit",
 				Status:      OutputStatusError,
 				RecordCount: 1,
-				GroupCount:  2,
 				Err:         errTestMapper,
 			},
 		},

--- a/stage.go
+++ b/stage.go
@@ -57,9 +57,8 @@ func StageTimeout(timeout time.Duration) PipelineStageOption {
 
 // ステージの実行結果
 type StageExecution struct {
-	Name        string
-	Type        ProcessorType
-	GroupCount  int
-	RecordCount int
-	Outputs     []SummarizedOutput // deprecated
+	Name       string
+	Type       ProcessorType
+	GroupCount int
+	Outputs    []SummarizedOutput
 }

--- a/stage.go
+++ b/stage.go
@@ -57,7 +57,9 @@ func StageTimeout(timeout time.Duration) PipelineStageOption {
 
 // ステージの実行結果
 type StageExecution struct {
-	Name    string
-	Type    ProcessorType
-	Outputs []SummarizedOutput
+	Name        string
+	Type        ProcessorType
+	GroupCount  int
+	RecordCount int
+	Outputs     []SummarizedOutput // deprecated
 }


### PR DESCRIPTION
Outputsで出力されたGroupCountでは、他のOutputとgroupの重複があるかを判定することができず、ステージを流れたグループのcountを正しく取得することができなかった。
代わりに、パイプラインのレイヤーでgroupの数を計測し、StageExecutionで利用できるようにする。